### PR TITLE
Configure Travis CI

### DIFF
--- a/.htmlhintrc
+++ b/.htmlhintrc
@@ -1,0 +1,22 @@
+{
+  "tagname-lowercase": true,
+  "attr-lowercase": true,
+  "attr-value-double-quotes": true,
+  "attr-value-not-empty": false,
+  "attr-no-duplication": true,
+  "doctype-first": false,
+  "tag-pair": true,
+  "tag-self-close": true,
+  "spec-char-escape": false,
+  "id-unique": true,
+  "src-not-empty": true,
+  "head-script-disabled": false,
+  "img-alt-require": true,
+  "doctype-html5": true,
+  "id-class-value": false,
+  "style-disabled": false,
+  "space-tab-mixed-disabled": false,
+  "id-class-ad-disabled": false,
+  "href-abs-or-rel": false,
+  "attr-unsafe-chars": false
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+language: ruby
+cache: bundler
+
+addons:
+  postgresql: "9.4"
+
+rvm:
+  - 2.2.3
+
+before_script:
+  - bundle exec rake before_commit:run
+  - cp config/database.travis.yml config/database.yml
+  - RAILS_ENV=test bundle exec rake db:create
+  - RAILS_ENV=test bundle exec rake --trace db:migrate
+  - npm install -g htmlhint
+
+script:
+  # - >-
+  #   BUNDLE_PATH=vendor/overcommit_bundle BUNDLE_GEMFILE=.overcommit_gems.rb bundle exec "overcommit --run" &&
+  #   htmlhint -c ./.htmlhintrc ./app/**/*.html.erb &&
+  #   bundle exec "rspec --format progress spec"
+  - >-
+    htmlhint -c ./.htmlhintrc ./app/**/*.html.erb &&
+    bundle exec "rspec --format progress spec"
+
+# Have this option to stop travis-ci building twice. Currently we have travis set to build both
+# PR's and pushes. However this means when we push to a PR we have to wait for Travis to finish
+# 2 builds. If we unticked 'pushes' when the PR was finally merged that would not be built. The
+# brute force approach would be to untick build PR's and just build all pushes. We instead have
+# gone with the approach outlined here http://stackoverflow.com/a/31882307
+branches:
+  only:
+    - master
+    - develop

--- a/config/database.travis.yml
+++ b/config/database.travis.yml
@@ -1,0 +1,4 @@
+test:
+  adapter: postgresql
+  database: travis_ci_test
+  username: postgres


### PR DESCRIPTION
We use Travis CI for continuous integration.
- Add `.travis.yml` to configure how to lint and test the app
- Add `.htmlhintrc` to define how the html is linted.
Note .htmlhintrc will be overwritten at build time when before_commit
starts installing that file. Until that point this file is required.
There is an issue raised to remove the file from this repo
once before_commit is updated.

Note this PR will not actually pass CI until merged.