### PR TITLE
Fix problem where links via PUT, POST, or DELETE generate CSRF errors

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,7 @@
     <!--[if IE 8]><%= stylesheet_link_tag "elements-page-ie8" %><![endif]-->
     <meta name="format-detection" content="telephone=no" />
     <%= javascript_include_tag "application", "data-turbolinks-track" => true %>
+    <%= csrf_meta_tags %>
 <% end %>
 
 <% page_title t(:global_proposition_header) %>


### PR DESCRIPTION
Adding `csrf_meta_tags` allows non-GET links to work without CSRF errors