### PR TITLE
Correct malformed html tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_script:
   - cp config/database.travis.yml config/database.yml
   - RAILS_ENV=test bundle exec rake db:create
   - RAILS_ENV=test bundle exec rake --trace db:migrate
-  - npm install -g htmlhint
+  #- npm install -g htmlhint
 
 script:
   # - >-
@@ -20,7 +20,6 @@ script:
   #   htmlhint -c ./.htmlhintrc ./app/**/*.html.erb &&
   #   bundle exec "rspec --format progress spec"
   - >-
-    htmlhint -c ./.htmlhintrc ./app/**/*.html.erb &&
     bundle exec "rspec --format progress spec"
 
 # Have this option to stop travis-ci building twice. Currently we have travis set to build both

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,13 +11,14 @@ GIT
 
 GIT
   remote: https://github.com/EnvironmentAgency/flood-risk-engine
-  revision: 6003cee8e657caf58857fc24c70ef0d69f9bc586
+  revision: 6e525b4d5745b16068b145ade4bcb2962794e911
   branch: develop
   specs:
     flood_risk_engine (0.0.1)
-      dibber (~> 0.4)
+      dibber (~> 0.5)
       dotenv-rails (~> 2.1)
       finite_machine (~> 0.10)
+      jquery-rails (~> 4.1)
       rails (~> 4.2)
       reform (~> 2.1)
       reform-rails (~> 0.1)
@@ -101,14 +102,14 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.10.0)
-    concurrent-ruby (1.0.1)
+    concurrent-ruby (1.0.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     database_cleaner (1.5.3)
     debug_inspector (0.0.2)
     declarative (0.0.7)
       uber (>= 0.0.15)
-    dibber (0.4.0)
+    dibber (0.5.0)
     diff-lcs (1.2.5)
     disposable (0.2.6)
       declarative (~> 0.0.6)

--- a/app/views/pages/gds_start_page.html
+++ b/app/views/pages/gds_start_page.html
@@ -26,7 +26,7 @@
 
     <p>
       <span class="bold-small"><%= t('.dredging_header') %></span>
-      <br>
+      <br/>
       <%= t('.dredging_text') %>
     </p>
 
@@ -47,7 +47,7 @@
     <div class="contact">
       <h3 class="heading-medium">Contact the Environment Agency</h3>
       <%= link_to 'enquiries@environment-agency.gov.uk', 'mailto:enquiries@environment-agency.gov.uk_url' %>
-      <br><%= t('.div_text16') %><br><%= t('.div_text17') %><br><%= t('.div_text18') %>
+      <br/><%= t('.div_text16') %><br/><%= t('.div_text17') %><br/><%= t('.div_text18') %>
     </div>
 
   </div>

--- a/config/initializers/ensure_env_vars_are_set.rb
+++ b/config/initializers/ensure_env_vars_are_set.rb
@@ -1,3 +1,7 @@
+# Check up-front that neccessary ENV vars are present. This prevents delayed
+# errors, for example email failing on first execution because of missing configuration.
+# You can add these variables in development or CI using your .env file.
+
 %w(SECRET_KEY_BASE).each do |key|
   ENV.fetch(key) { raise "#{key} not found in ENV" }
 end


### PR DESCRIPTION
- Fix malformed html tags identified by htmlhint.
- Update flood_risk_engine gem reference.
- Temporarily removed htmlhinting do to [this error](https://github.com/yaniswang/HTMLHint/issues/132) installing htmlhint - waiting for this to be resolved by the package author