### PR TITLE
Fix radio button and checkbox highlighting

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,4 +13,22 @@
 //= require jquery
 //= require jquery_ujs
 //= require flood_risk_engine/application
-//= require_tree .
+//= require govuk/selection-buttons
+//= require show_hide
+//
+
+
+$(document).ready(function() {
+
+  // Use GOV.UK selection-buttons.js to set selected
+  // and focused states for block labels
+  var $blockLabels = $(".block-label input[type='radio'], .block-label input[type='checkbox']");
+  new GOVUK.SelectionButtons($blockLabels);
+
+  // Show and hide toggled content
+  // Where .block-label uses the data-target attribute
+  var toggleContent = new ShowHideContent();
+  toggleContent.showHideRadioToggledContent();
+  toggleContent.showHideCheckboxToggledContent();
+
+});

--- a/app/assets/javascripts/show_hide.js
+++ b/app/assets/javascripts/show_hide.js
@@ -1,0 +1,113 @@
+
+function ShowHideContent() {
+  var self = this;
+
+  self.escapeElementName = function(str) {
+    result = str.replace('[', '\\[').replace(']', '\\]');
+    return(result);
+  };
+
+  self.showHideRadioToggledContent = function () {
+    $(".block-label input[type='radio']").each(function () {
+
+      var $radio = $(this);
+      var $radioGroupName = $radio.attr('name');
+      var $radioLabel = $radio.parent('label');
+
+      var dataTarget = $radioLabel.attr('data-target');
+
+      // Add ARIA attributes
+
+      // If the data-target attribute is defined
+      if (dataTarget) {
+
+        // Set aria-controls
+        $radio.attr('aria-controls', dataTarget);
+
+        $radio.on('click', function () {
+
+          // Select radio buttons in the same group
+          $radio.closest('form').find(".block-label input[name=" + self.escapeElementName($radioGroupName) + "]").each(function () {
+            var $this = $(this);
+
+            var groupDataTarget = $this.parent('label').attr('data-target');
+            var $groupDataTarget = $('#' + groupDataTarget);
+
+            // Hide toggled content
+            $groupDataTarget.hide();
+            // Set aria-expanded and aria-hidden for hidden content
+            $this.attr('aria-expanded', 'false');
+            $groupDataTarget.attr('aria-hidden', 'true');
+          });
+
+          var $dataTarget = $('#' + dataTarget);
+          $dataTarget.show();
+          // Set aria-expanded and aria-hidden for clicked radio
+          $radio.attr('aria-expanded', 'true');
+          $dataTarget.attr('aria-hidden', 'false');
+
+        });
+
+      } else {
+        // If the data-target attribute is undefined for a radio button,
+        // hide visible data-target content for radio buttons in the same group
+
+        $radio.on('click', function () {
+
+          // Select radio buttons in the same group
+          $(".block-label input[name=" + self.escapeElementName($radioGroupName) + "]").each(function () {
+
+            var groupDataTarget = $(this).parent('label').attr('data-target');
+            var $groupDataTarget = $('#' + groupDataTarget);
+
+            // Hide toggled content
+            $groupDataTarget.hide();
+            // Set aria-expanded and aria-hidden for hidden content
+            $(this).attr('aria-expanded', 'false');
+            $groupDataTarget.attr('aria-hidden', 'true');
+          });
+
+        });
+      }
+
+    });
+  };
+  self.showHideCheckboxToggledContent = function () {
+
+    $(".block-label input[type='checkbox']").each(function() {
+
+      var $checkbox = $(this);
+      var $checkboxLabel = $(this).parent();
+
+      var $dataTarget = $checkboxLabel.attr('data-target');
+
+      // Add ARIA attributes
+
+      // If the data-target attribute is defined
+      if (typeof $dataTarget !== 'undefined' && $dataTarget !== false) {
+
+        // Set aria-controls
+        $checkbox.attr('aria-controls', $dataTarget);
+
+        // Set aria-expanded and aria-hidden
+        $checkbox.attr('aria-expanded', 'false');
+        $('#'+$dataTarget).attr('aria-hidden', 'true');
+
+        // For checkboxes revealing hidden content
+        $checkbox.on('click', function() {
+
+          var state = $(this).attr('aria-expanded') === 'false' ? true : false;
+
+          // Toggle hidden content
+          $('#'+$dataTarget).toggle();
+
+          // Update aria-expanded and aria-hidden attributes
+          $(this).attr('aria-expanded', state);
+          $('#'+$dataTarget).attr('aria-hidden', !state);
+
+        });
+      }
+
+    });
+  };
+}


### PR DESCRIPTION
* Fix radio button and checkbox highlighting by pulling in the govuk/selection-buttons.js from the govuk_frontend_toolkit gem.
* copy in show/hide functions from prototype
* wire up new handlers in document ready in application.js, as per prototype