### PR TITLE
Remove turbolinks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,8 +37,6 @@ gem "coffee-rails", "~> 4.1.0"
 
 # Use jquery as the JavaScript library
 gem "jquery-rails"
-# Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
-gem "turbolinks"
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem "jbuilder", "~> 2.0"
 # bundle exec rake doc:rails generates the API under doc/api.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -373,8 +373,6 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.5)
-    turbolinks (2.5.3)
-      coffee-rails
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uber (0.0.15)
@@ -458,7 +456,6 @@ DEPENDENCIES
   spring-commands-rspec
   stackprof
   test_after_commit (~> 1.0.0)
-  turbolinks
   uglifier (>= 1.3.0)
   vcr (~> 3.0.1)
   web-console (~> 2.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,6 +12,5 @@
 //
 //= require jquery
 //= require jquery_ujs
-//= require turbolinks
 //= require flood_risk_engine/application
 //= require_tree .

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,10 +1,10 @@
 <% content_for(:head) do %>
-  <!--[if gt IE 8]><!--><%= stylesheet_link_tag "application", media: "all", "data-turbolinks-track" => true %><!--<![endif]-->
+  <!--[if gt IE 8]><!--><%= stylesheet_link_tag "application", media: "all" %><!--<![endif]-->
   <!--[if IE 6]><%= stylesheet_link_tag "elements-page-ie6" %><![endif]-->
   <!--[if IE 7]><%= stylesheet_link_tag "elements-page-ie7" %><![endif]-->
   <!--[if IE 8]><%= stylesheet_link_tag "elements-page-ie8" %><![endif]-->
   <meta name="format-detection" content="telephone=no" />
-  <%= javascript_include_tag "application", "data-turbolinks-track" => true %>
+  <%= javascript_include_tag "application" %>
   <%= csrf_meta_tags %>
 <% end %>
 


### PR DESCRIPTION
Remove the turbo_links gem and references to it as we don't use it.
Reference issue #73 