### PR TITLE
Update the flood_risk_engine gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 GIT
   remote: https://github.com/EnvironmentAgency/flood-risk-engine
-  revision: da578efd9ed10a89557fb200245c247b93fe105c
+  revision: d036e5a20fabe31201dc09ec4010a0bc10394750
   branch: develop
   specs:
     flood_risk_engine (0.0.1)
-      activerecord-session_store (~> 0.1)
+      activerecord-session_store (~> 1.0)
       airbrake (~> 5.3.0)
       airbrake-ruby (~> 1.3.2)
       dibber (~> 0.5)
@@ -57,10 +57,12 @@ GEM
       activemodel (= 4.2.6)
       activesupport (= 4.2.6)
       arel (~> 6.0)
-    activerecord-session_store (0.1.2)
-      actionpack (>= 4.0.0, < 5)
-      activerecord (>= 4.0.0, < 5)
-      railties (>= 4.0.0, < 5)
+    activerecord-session_store (1.0.0)
+      actionpack (>= 4.0, < 5.1)
+      activerecord (>= 4.0, < 5.1)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 1.5.2, < 3)
+      railties (>= 4.0, < 5.1)
     activesupport (4.2.6)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
@@ -117,7 +119,7 @@ GEM
       safe_yaml (~> 1.0.0)
     database_cleaner (1.5.3)
     debug_inspector (0.0.2)
-    declarative (0.0.7)
+    declarative (0.0.8)
       uber (>= 0.0.15)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)

--- a/spec/support/expectations.rb
+++ b/spec/support/expectations.rb
@@ -106,7 +106,7 @@ end
 RSpec::Matchers.define :have_nothing_selected do
   match do |page_object|
     page_object.class.radio_button_ids.each do |id|
-      expect(find('#' + id)).to_not be_checked
+      expect(find("#" + id)).to_not be_checked
     end
   end
 end

--- a/spec/support/page_objects/check_location_page_object.rb
+++ b/spec/support/page_objects/check_location_page_object.rb
@@ -9,11 +9,11 @@ class CheckLocationPageObject < BasePageObject
   radio_button_helpers [:yes_option, :no_option]
 
   def yes_checked?
-    expect(find('#yes_option')).to be_checked
+    expect(find("#yes_option")).to be_checked
   end
 
   def no_checked?
-    expect(find('#no_option')).to_not be_checked
+    expect(find("#no_option")).to_not be_checked
   end
 
   def advance_page(yes = true)


### PR DESCRIPTION
This brings in latest engine changes including the journey_cookie httponly fix.