### PR TITLE
Move app-specific configuration from the engine to the app

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/EnvironmentAgency/flood-risk-engine
-  revision: d036e5a20fabe31201dc09ec4010a0bc10394750
+  revision: 9f6c8e4432d4da58d4af84cd5b8b5ab9ca7d53da
   branch: develop
   specs:
     flood_risk_engine (0.0.1)
@@ -304,7 +304,7 @@ GEM
     sprockets (3.6.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.0.4)
+    sprockets-rails (3.1.1)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)

--- a/config/initializers/01_check_for_presence_of_required_env_vars.rb
+++ b/config/initializers/01_check_for_presence_of_required_env_vars.rb
@@ -1,0 +1,25 @@
+# Check up-front that neccessary ENV vars are present. This prevents delayed
+# errors, for example email failing on first execution because of missing configuration.
+# You can add these variables in development or CI using your .env file.
+%w(
+  SECRET_KEY_BASE
+  ADDRESS_FACADE_SERVER
+  ADDRESS_FACADE_PORT
+  ADDRESS_FACADE_CLIENT_ID
+  ADDRESS_FACADE_KEY
+  DEVISE_MAILER_SENDER
+  EMAIL_HOST
+  EMAIL_PORT
+).each do |key|
+  ENV.fetch(key) { raise "#{key} not found in ENV" }
+end
+
+# Ensure presence of any essential production ENV vars
+if Rails.env.production?
+  %w(
+    AIRBRAKE_HOST
+    AIRBRAKE_PROJECT_KEY
+  ).each do |key|
+    ENV.fetch(key) { raise "#{key} not found in ENV" }
+  end
+end

--- a/config/initializers/02_airbrake.rb
+++ b/config/initializers/02_airbrake.rb
@@ -1,0 +1,63 @@
+# Airbrake is an online tool that provides robust exception tracking in your Rails
+# applications. In doing so, it allows you to easily review errors, tie an error
+# to an individual piece of code, and trace the cause back to recent
+# changes. Airbrake enables for easy categorization, searching, and prioritization
+# of exceptions so that when errors occur, your team can quickly determine the
+# root cause.
+#
+# Configuration details:
+# https://github.com/airbrake/airbrake-ruby#configuration
+require_dependency "airbrake"
+
+if Rails.env.production?
+
+  Airbrake.configure do |c|
+
+    # You must set both project_id & project_key. To find your project_id and
+    # project_key navigate to your project's General Settings and copy the values
+    # from the right sidebar.
+    # https://github.com/airbrake/airbrake-ruby#project_id--project_key
+    c.host = Rails.application.secrets.airbrake_host
+    c.project_key = Rails.application.secrets.airbrake_project_key
+    c.project_id = true # Errbit doesn't require a specific project_id, so setting to true
+
+    # Configures the root directory of your project. Expects a String or a
+    # Pathname, which represents the path to your project. Providing this option
+    # helps us to filter out repetitive data from backtrace frames and link to
+    # GitHub files from our dashboard.
+    # https://github.com/airbrake/airbrake-ruby#root_directory
+    c.root_directory = Rails.root
+
+    # By default, Airbrake Ruby outputs to STDOUT. In Rails apps it makes sense to
+    # use the Rails' logger.
+    # https://github.com/airbrake/airbrake-ruby#logger
+    c.logger = Rails.logger
+
+    # Configures the environment the application is running in. Helps the Airbrake
+    # dashboard to distinguish between exceptions occurring in different
+    # environments. By default, it's not set.
+    # NOTE: This option must be set in order to make the 'ignore_environments'
+    # option work.
+    # https://github.com/airbrake/airbrake-ruby#environment
+    c.environment = Rails.env
+
+    # Setting this option allows Airbrake to filter exceptions occurring in
+    # unwanted environments such as :test. By default, it is equal to an empty
+    # Array, which means Airbrake Ruby sends exceptions occurring in all
+    # environments.
+    # NOTE: This option *does not* work if you don't set the 'environment' option.
+    # https://github.com/airbrake/airbrake-ruby#ignore_environments
+    c.ignore_environments = %w[development test]
+
+    # A list of parameters that should be filtered out of what is sent to
+    # Airbrake. By default, all "password" attributes will have their contents
+    # replaced.
+    # https://github.com/airbrake/airbrake-ruby#blacklist_keys
+    c.blacklist_keys = [/password/i]
+  end
+
+  # If Airbrake doesn't send any expected exceptions, we suggest to uncomment the
+  # line below. It might simplify debugging of background Airbrake workers, which
+  # can silently die.
+  # Thread.abort_on_exception = ['test', 'development'].include?(Rails.env)
+end

--- a/config/initializers/address_lookup.rb
+++ b/config/initializers/address_lookup.rb
@@ -1,0 +1,8 @@
+EA::AddressLookup.configure do |config|
+  config.address_facade_server    = Rails.application.secrets.address_facade_server
+  config.address_facade_port      = Rails.application.secrets.address_facade_port
+  config.address_facade_url       = "/address-service/v1/addresses/postcode"
+  config.timeout_in_seconds       = Rails.application.secrets.address_facade_timeout
+  config.address_facade_client_id = Rails.application.secrets.address_facade_client_id
+  config.address_facade_key       = Rails.application.secrets.address_facade_key
+end

--- a/config/initializers/area_lookup.rb
+++ b/config/initializers/area_lookup.rb
@@ -1,0 +1,3 @@
+EA::AreaLookup.configure do |config|
+  # config.administrative_area_api_url = ?
+end


### PR DESCRIPTION
Rather than for example having an initialiser in the
engine to setup the address_lookup configuration, let the host
app do this.