### PR TITLE
Add a present? check for GOOGLE_TAG

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,7 +30,7 @@
 <%
   content_for(:body_start) do
     render("shared/google_analytics", google_tag: ENV["GOOGLE_TAG"])
-  end if ENV["GOOGLE_TAG"]
+  end if ENV["GOOGLE_TAG"].present?
 %>
 
 <% content_for(:content) do %>


### PR DESCRIPTION
This lets us add an empty GOOGLE_TAG ENV var
without it triggering the output of the analytics script.