### PR TITLE
RIP-289 Update service title again

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,7 +2,7 @@
 en:
   back: Back
   backto_start_link: Back
-  global_proposition_header: Register a flood risk activity
+  global_proposition_header: Register a flood risk activity exemption
   global:
     continue: Continue
   layouts:


### PR DESCRIPTION
Update service title text in banner, add the word 'exemption' as
previously supplied text was incorrect.