### PR TITLE
RIP-300 Update footer telephone number url

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,7 +2,7 @@
   <p>
     <%= t('flood_risk_engine.shared.footer.support_text') %>
     <%= link_to t("flood_risk_engine.shared.footer..helpline_telephone_number"),
-                "tel: #{t "flood_risk_engine.shared.footer.helpline_telephone_number_uri" }" %>
+                "tel:#{t "flood_risk_engine.shared.footer.helpline_telephone_number_uri" }" %>
   </p>
   <ul>
     <li class="inline"><%= link_to 'Privacy', page_path('privacy_policy'),  target: "_blank" %></li>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RIP-300

Remove a space in the telephone footer link URL, bring in new
number format from:
https://github.com/EnvironmentAgency/flood-risk-engine/pull/206