### PR TITLE
Resolve layout issues in IE8

### DIFF
--- a/app/assets/stylesheets/ie8.css.scss
+++ b/app/assets/stylesheets/ie8.css.scss
@@ -18,3 +18,38 @@ label.exemption {
 #content {
   margin: 0 auto;
 }
+
+// IE8 doesn't support media queries so we have to redefine these input
+// widths here instead.
+
+.form-control-char-auto { // intended for select options that have pre-populated text
+  width: auto;
+}
+
+.form-control-char-50 {
+  width: 26em;
+}
+
+.form-control-char-35 {
+  width: 18.5em;
+}
+
+.form-control-char-25 {
+  width: 13.5em;
+}
+
+.form-control-char-15 {
+  width: 8.5em;
+}
+
+.form-control-char-10 {
+  width: 6em;
+}
+
+.form-control-char-5 {
+  width: 3.5em;
+}
+
+.form-control-char-3 {
+  width: 2.5em;
+}

--- a/app/assets/stylesheets/ie8.css.scss
+++ b/app/assets/stylesheets/ie8.css.scss
@@ -14,3 +14,7 @@ label.exemption {
   padding-right: 100px;
   width: 66.6666666667%;
 }
+
+#content {
+  margin: 0 auto;
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:head) do %>
-  <!--[if gt IE 8]><!--><%= stylesheet_link_tag "application", media: "all" %><!--<![endif]-->
+  <%= stylesheet_link_tag "application", media: "all" %>
   <!--[if IE 8]><%= stylesheet_link_tag "ie8" %><![endif]-->
   <meta name="format-detection" content="telephone=no" />
   <%= javascript_include_tag "application" %>


### PR DESCRIPTION
Resolves reported layout issues in IE8 by removing the conditional around the stylesheet. Also centers the content div in a different way for IE8, as suggested by Martin.