### PR TITLE
RIP-279 Fix mobile exemption display

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/EnvironmentAgency/flood-risk-engine
-  revision: 0b7b7f0f993510272468d7fc311da8f990ac0c50
+  revision: cc3e03f166afd8f15f5e49e31570d91338287cf9
   branch: develop
   specs:
     flood_risk_engine (0.0.1)

--- a/app/assets/stylesheets/partials/_forms.scss
+++ b/app/assets/stylesheets/partials/_forms.scss
@@ -34,7 +34,7 @@ label.exemption
   padding-right: 4em;
 }
 
-@media screen and (min-width: 320px)
+@media screen and (min-width: 420px)
 {
   label.exemption
   {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RIP-279

Fixes an issue whereby on iPhone 5 and 6 the exemption label grey box
touches the right margin.