### PR TITLE
RIP-334 Times shown an hour off

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -30,8 +30,7 @@ module FloodRiskFrontOffice
     # -- all .rb files in that directory are automatically loaded.
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
-    # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-    # config.time_zone = 'Central Time (US & Canada)'
+    config.time_zone = 'London'
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RIP-334

Set the Rails application time zone to convert dates (stored in UTC)
in the database to London/UK time automatically in views.