### PR TITLE
Update to version 1 0 1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ ruby "2.3.1"
 
 gem "flood_risk_engine",
     git: "https://github.com/EnvironmentAgency/flood-risk-engine",
-    tag: "v1.0.0"
+    tag: "v1.0.1"
 
 gem "rails", "4.2.7.1"
 gem "pg", "~> 0.18.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/EnvironmentAgency/flood-risk-engine
-  revision: 0d72f18320150bbe014d34c91863ae757bd7ad9f
-  tag: v1.0.0
+  revision: eab66c2e2efd2c1da37bd23bf655b65173de0564
+  tag: v1.0.1
   specs:
-    flood_risk_engine (1.0.0)
+    flood_risk_engine (1.0.1)
       activerecord-session_store (~> 1.0)
       airbrake (~> 5.3.0)
       airbrake-ruby (~> 1.3.2)
@@ -121,7 +121,7 @@ GEM
       representable (>= 2.4.0, <= 3.1.0)
       uber
     docile (1.1.5)
-    domain_name (0.5.20160615)
+    domain_name (0.5.20161129)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.1.1)
     dotenv-rails (2.1.1)
@@ -158,7 +158,7 @@ GEM
     has_secure_token (1.0.0)
       activerecord (>= 3.0)
     high_voltage (3.0.0)
-    http-cookie (1.0.2)
+    http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (0.7.0)
     ice_nine (0.11.2)
@@ -187,7 +187,7 @@ GEM
       rack
       rake (>= 0.8.1)
     pg (0.18.4)
-    phonelib (0.6.2)
+    phonelib (0.6.8)
     pkg-config (1.1.7)
     poltergeist (1.9.0)
       capybara (~> 2.1)
@@ -239,9 +239,9 @@ GEM
       representable (>= 2.4.0, < 3.1.0)
       uber (~> 0.0.11)
     reform-rails (0.1.0)
-    representable (3.0.0)
+    representable (3.0.2)
       declarative (~> 0.0.5)
-      uber (~> 0.0.15)
+      uber (>= 0.0.15, < 0.2.0)
     rest-client (2.0.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
@@ -296,7 +296,7 @@ GEM
     uber (0.0.15)
     uglifier (3.0.0)
       execjs (>= 0.3.0, < 3)
-    uk_postcode (2.1.0)
+    uk_postcode (2.1.1)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.2)
@@ -362,4 +362,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.12.5
+   1.13.6

--- a/config/initializers/version.rb
+++ b/config/initializers/version.rb
@@ -1,3 +1,3 @@
 class Application
-  VERSION = "1.0.0".freeze
+  VERSION = "1.0.1".freeze
 end


### PR DESCRIPTION
This release includes changes in flood-risk-engine which resolve an issue on the Grid Reference page when viewed in FireFox.