### PR TITLE
Add OS places notice and T&C's to service

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "dotenv-rails", "~> 2.1"
 
 gem "flood_risk_engine",
     git: "https://github.com/EnvironmentAgency/flood-risk-engine",
-    tag: "v1.0.1"
+    tag: "v1.0.2"
 
 gem "govuk_elements_rails", "~> 1.2.1"
 # Access to some of the most common styles and scripts used by GDS

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/EnvironmentAgency/flood-risk-engine
-  revision: eab66c2e2efd2c1da37bd23bf655b65173de0564
-  tag: v1.0.1
+  revision: c2e2f5845de94480e1b2f85010ce6dbc72264c9e
+  tag: v1.0.2
   specs:
-    flood_risk_engine (1.0.1)
+    flood_risk_engine (1.0.2)
       activerecord-session_store (~> 1.0)
       airbrake (~> 5.3.0)
       airbrake-ruby (~> 1.3.2)
@@ -108,7 +108,7 @@ GEM
       simplecov (>= 0.7.1, < 1.0.0)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
-    concurrent-ruby (1.0.2)
+    concurrent-ruby (1.0.3)
     debug_inspector (0.0.2)
     declarative (0.0.8)
       uber (>= 0.0.15)
@@ -288,7 +288,7 @@ GEM
       json (~> 1.8)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
-    sprockets (3.7.0)
+    sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.0)


### PR DESCRIPTION
The actual changes have been done in the [Flood risk engine](https://github.com/EnvironmentAgency/flood-risk-engine/) but this change brings in the version of the engine which includes it.