### PR TITLE
Update version to 1.0.2 ready for release

### DIFF
--- a/config/initializers/version.rb
+++ b/config/initializers/version.rb
@@ -1,3 +1,3 @@
 class Application
-  VERSION = "1.0.1".freeze
+  VERSION = "1.0.2".freeze
 end


### PR DESCRIPTION
This covers all work required to prepare the Flood risk activity exemptions registration service for its next release.

N.B. This essentially cancels out 67cddcf. All we need to do to get the next release out is update the version no, and that's what that commit did.

However we then found there was already an existing tag for a version 1.0.1, pointing to commit 59d4490, so that should be considered v1.0.1. To get things back in order we need to increment the version again to version 1.0.2, and that's what'll be our next release.